### PR TITLE
pkg/libpng: Do not specify -O3

### DIFF
--- a/pkg/libpng-1.6.23
+++ b/pkg/libpng-1.6.23
@@ -2,5 +2,5 @@ URL=http://download.sourceforge.net/libpng/libpng-1.6.23.tar.gz
 DESC="PNG library"
 USER_CFGARGS="--disable-shared --enable-static --enable-arm-neon"
 DEPS="zlib"
-CFLAGS="${CFLAGS} -std=c99 -ftree-vectorize -O3 -mword-relocations -fomit-frame-pointer -ffast-math -DPNG_NO_CONSOLE_IO -ffat-lto-objects -flto"
+CFLAGS="${CFLAGS} -std=c99 -ftree-vectorize -mword-relocations -fomit-frame-pointer -ffast-math -DPNG_NO_CONSOLE_IO -ffat-lto-objects -flto"
 IGNORE_CMAKE=true


### PR DESCRIPTION
Specifying optimization in the file overrides config.