### PR TITLE
Add libpsp2shell.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,4 @@ script:
     - ./vdpm -i libmad
     - ./vdpm -i libogg
     - ./vdpm -i libvorbis
+    - ./vdpm -i libpsp2shell

--- a/pkg/libpsp2shell
+++ b/pkg/libpsp2shell
@@ -1,0 +1,4 @@
+URL=https://github.com/Cpasjuste/PSP2SHELL
+TYPE=git
+DESC="remote debugging shell library"
+CMARGS="-DCMAKE_TOOLCHAIN_FILE=Vita.cmake"


### PR DESCRIPTION
~~Not ready to merge until Cpasjuste/PSP2SHELL#2 is merged.~~ It was merged as I was writing this. Also it needs another PR to install the headers, so please hold.

psp2shell is a small client/server pair for remotely debugging and reloading Vita applications.